### PR TITLE
Cryptr init commit

### DIFF
--- a/lib/cryptr.rb
+++ b/lib/cryptr.rb
@@ -1,0 +1,46 @@
+require 'cryptr/version'
+require 'base64'
+
+# Cryptr is a minimal encryption module that follows the standard of AES-256-CBC
+# A random iv is generated each time and prepended to the encrypted message
+module Cryptr
+  ENCRYPTION_METHOD = 'aes-256-cbc'.freeze
+  IV_LENGTH = 16
+
+  # encrypts data with the given key. returns a binary data with the
+  # unhashed random iv in the first 16 bytes
+  def self.encrypt(key, data)
+    cipher = OpenSSL::Cipher::Cipher.new(ENCRYPTION_METHOD)
+    cipher.encrypt
+    cipher.key = key = Digest::SHA256.digest(key)
+    random_iv = cipher.random_iv
+    cipher.iv = Digest::SHA256.digest(random_iv + key)[0...IV_LENGTH]
+    encrypted = cipher.update(data)
+    encrypted << cipher.final
+    random_iv + encrypted
+  end
+
+  def self.decrypt(key, data) # rubocop:disable Metrics/MethodLength
+    cipher = OpenSSL::Cipher::Cipher.new(ENCRYPTION_METHOD)
+    cipher.decrypt
+    cipher.key = cipher_key = Digest::SHA256.digest(key)
+    random_iv = data[0...IV_LENGTH]
+    data = data[IV_LENGTH..-1]
+    cipher.iv = Digest::SHA256.digest(random_iv + cipher_key)[0...IV_LENGTH]
+    begin
+      decrypted = cipher.update(data)
+      decrypted << cipher.final
+    rescue OpenSSL::OpenSSLError, TypeError
+      return nil
+    end
+    decrypted
+  end
+
+  def self.encrypt64(key, data)
+    Base64.encode64(encrypt(key, data))
+  end
+
+  def self.decrypt64(key, data)
+    decrypt(key, Base64.decode64(data))
+  end
+end

--- a/test/cryptr_test.rb
+++ b/test/cryptr_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+require 'securerandom'
+
+class CryptrTest < Minitest::Test
+  def test_it_can_decrypt_encrypt_random_data
+    100.times do
+      data = SecureRandom.base64
+      key = 'some_key'
+      assert data == Cryptr.decrypt(key, Cryptr.encrypt(key, data))
+    end
+  end
+
+  def test_it_can_decrypt_encrypt_random_data_base64
+    100.times do
+      data = SecureRandom.base64
+      key = 'some_key'
+      assert data == Cryptr.decrypt64(key, Cryptr.encrypt64(key, data))
+    end
+  end
+end


### PR DESCRIPTION
Introducing cryptr, a minimal encryption module that follows the standard of AES-256-CBC.

The current encryptor gem we are using is not secure (version 1.3.0), and version 3.0.0 doesn't concat iv into the encrypted message, which requires separate handling of the field. This gem is a simplified version of it, and it can be used for kafka encryption/decryption for both producers and consumers.