### PR TITLE
Add multi-decrypt support

### DIFF
--- a/lib/cryptr.rb
+++ b/lib/cryptr.rb
@@ -46,4 +46,16 @@ module Cryptr
   def self.decrypt64(key, data)
     decrypt(key, Base64.decode64(data))
   end
+
+  # multi_decrypt uses the keys in order to decrypt data
+  # useful for key rotation
+  # WARNING notice that it may decrypt to some arbitrary data using the wrong
+  # key, but it's up to the downstream to validate the correctness of the data
+  def self.multi_decrypt(keys, data)
+    keys.map { |key| decrypt(key, data) }
+  end
+
+  def self.multi_decrypt64(keys, data)
+    keys.map { |key| decrypt64(key, data) }
+  end
 end

--- a/lib/cryptr/version.rb
+++ b/lib/cryptr/version.rb
@@ -1,3 +1,3 @@
 module Cryptr
-  VERSION = '0.1.1'.freeze
+  VERSION = '0.1.2'.freeze
 end

--- a/test/cryptr_test.rb
+++ b/test/cryptr_test.rb
@@ -1,9 +1,12 @@
 require 'test_helper'
 require 'securerandom'
 
+# rubocop:disable Metrics/AbcSize
+# rubocop:disable Metrics/MethodLength
+
 class CryptrTest < Minitest::Test
   def test_it_can_decrypt_encrypt_random_data
-    100.times do
+    1000.times do
       data = SecureRandom.base64
       key = 'some_key'
       assert data == Cryptr.decrypt(key, Cryptr.encrypt(key, data))
@@ -11,10 +14,58 @@ class CryptrTest < Minitest::Test
   end
 
   def test_it_can_decrypt_encrypt_random_data_base64
-    100.times do
+    1000.times do
       data = SecureRandom.base64
       key = 'some_key'
       assert data == Cryptr.decrypt64(key, Cryptr.encrypt64(key, data))
+    end
+  end
+
+  def test_it_can_decrypt_encrypt_with_multi_keys
+    1000.times do
+      data = SecureRandom.base64
+      key1 = 'some_key_1'
+      key2 = 'some_key_2'
+      key3 = 'some_key_3'
+
+      assert Cryptr.multi_decrypt(
+        [key1, key2],
+        Cryptr.encrypt(key1, data)
+      ).include?(data)
+
+      assert Cryptr.multi_decrypt(
+        [key1, key2],
+        Cryptr.encrypt(key2, data)
+      ).include?(data)
+
+      assert !Cryptr.multi_decrypt(
+        [key1, key2],
+        Cryptr.encrypt(key3, data)
+      ).include?(data)
+    end
+  end
+
+  def test_it_can_decrypt_encrypt_with_multi_keys_base64
+    1000.times do
+      data = SecureRandom.base64
+      key1 = 'some_key_1'
+      key2 = 'some_key_2'
+      key3 = 'some_key_3'
+
+      assert Cryptr.multi_decrypt64(
+        [key1, key2],
+        Cryptr.encrypt64(key1, data)
+      ).include?(data)
+
+      assert Cryptr.multi_decrypt64(
+        [key1, key2],
+        Cryptr.encrypt64(key2, data)
+      ).include?(data)
+
+      assert !Cryptr.multi_decrypt64(
+        [key1, key2],
+        Cryptr.encrypt64(key3, data)
+      ).include?(data)
     end
   end
 end


### PR DESCRIPTION
Add support for `multi_decrypt` and `multi_decrypt64`, so that we can rotate the keys.

To rotate the keys

1. Prepend the new key to the keys in the consumer
2. Change the key to be the new key in the producer
3. Wait at least X minutes
4. Remove the old key from the keys list in the consumer