### PR TITLE
Add simplebox support and improve multi_decrypt

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,22 @@
 PATH
   remote: .
   specs:
-    cryptr (0.1.1)
+    cryptr (0.1.3)
       openssl
+      rbnacl
+      rbnacl-libsodium
 
 GEM
   remote: https://rubygems.org/
   specs:
+    ffi (1.9.18)
     minitest (5.10.3)
     openssl (2.0.6)
     rake (10.4.2)
+    rbnacl (5.0.0)
+      ffi
+    rbnacl-libsodium (1.0.13)
+      rbnacl (>= 3.0.1)
 
 PLATFORMS
   ruby

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Cryptr
 
-Cryptr is a minimal encryption module that follows the standard of AES-256-CBC. A random iv is generated each time and prepended to the encrypted message.
+Cryptr is a minimal encryption module that follows the standard of SimpleBox or AES-256-CBC.
+
+- SimpleBox: is recommended, and it handles multi_decrypyt gracefully._
+- AES-256-CRC: A random iv is generated each time and prepended to the encrypted message.
 
 ## Installation
 
@@ -15,10 +18,20 @@ gem 'cryptr'
 ```ruby
 require 'cryptr'
 
+# Simplebox (recommended)
+
+# hex string
+SimpleboxCryptr.encrypt(key, data)
+SimpleboxCryptr.decrypt(key, data)
+# base64
+SimpleboxCryptr.encrypt64(key, data)
+SimpleboxCryptr.decrypt64(key, data)
+
+# AES-256-CBC
+
 # hex string
 Cryptr.encrypt(key, data)
 Cryptr.decrypt(key, data)
-
 # base64
 Cryptr.encrypt64(key, data)
 Cryptr.decrypt64(key, data)
@@ -29,7 +42,3 @@ Cryptr.decrypt64(key, data)
 ```
 rake test
 ```
-
-## License
-
-The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/cryptr.gemspec
+++ b/cryptr.gemspec
@@ -31,6 +31,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "openssl"
+  spec.add_dependency "rbnacl-libsodium"
+  spec.add_dependency "rbnacl"
 
   spec.add_development_dependency "bundler", "~> 1.16.a"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/cryptr/version.rb
+++ b/lib/cryptr/version.rb
@@ -1,3 +1,3 @@
 module Cryptr
-  VERSION = '0.1.2'.freeze
+  VERSION = '0.1.3'.freeze
 end

--- a/test/cryptr_test.rb
+++ b/test/cryptr_test.rb
@@ -3,6 +3,7 @@ require 'securerandom'
 
 # rubocop:disable Metrics/AbcSize
 # rubocop:disable Metrics/MethodLength
+# rubocop:disable Metrics/LineLength
 
 class CryptrTest < Minitest::Test
   def test_it_can_decrypt_encrypt_random_data
@@ -66,6 +67,56 @@ class CryptrTest < Minitest::Test
         [key1, key2],
         Cryptr.encrypt64(key3, data)
       ).include?(data)
+    end
+  end
+end
+
+class SimpleboxCryptrTest < Minitest::Test
+  def test_it_can_simplebox_decrypt_encrypt_random_data
+    1000.times do
+      data = SecureRandom.base64
+      key = SimpleboxCryptr.gen_key
+      assert data == SimpleboxCryptr.decrypt(key, SimpleboxCryptr.encrypt(key, data))
+    end
+
+    1000.times do
+      data = SecureRandom.base64
+      key = SimpleboxCryptr.gen_key
+      assert data == SimpleboxCryptr.decrypt64(key, SimpleboxCryptr.encrypt64(key, data))
+    end
+  end
+
+  def test_it_can_simplebox_decrypt_with_wrong_key
+    1000.times do
+      data = SecureRandom.base64
+      key1 = SimpleboxCryptr.gen_key
+      key2 = SimpleboxCryptr.gen_key
+      assert SimpleboxCryptr.decrypt(key2, SimpleboxCryptr.encrypt(key1, data)).nil?
+      assert SimpleboxCryptr.decrypt64(key2, SimpleboxCryptr.encrypt64(key1, data)).nil?
+    end
+  end
+
+  def test_simplebox_multi
+    1000.times do
+      data = SecureRandom.base64
+      key1 = SimpleboxCryptr.gen_key
+      key2 = SimpleboxCryptr.gen_key
+      key3 = SimpleboxCryptr.gen_key
+
+      assert data == SimpleboxCryptr.multi_decrypt64(
+        [key1, key2],
+        SimpleboxCryptr.encrypt64(key1, data)
+      )
+
+      assert data == SimpleboxCryptr.multi_decrypt64(
+        [key1, key2],
+        SimpleboxCryptr.encrypt64(key2, data)
+      )
+
+      assert SimpleboxCryptr.multi_decrypt64(
+        [key1, key2],
+        SimpleboxCryptr.encrypt64(key3, data)
+      ).nil?
     end
   end
 end


### PR DESCRIPTION
Simplebox https://github.com/cryptosphere/rbnacl/wiki/SimpleBox

Looks like this is the new standard of cryptr. And it's better b/c it always throws `RbNaCl::CryptoError` if it fails, so we can safely use it to `multi_decrypt`