### PR TITLE
Fix frozen string error and deprecation warning

### DIFF
--- a/lib/cryptr.rb
+++ b/lib/cryptr.rb
@@ -15,7 +15,7 @@ module Cryptr
   # encrypts data with the given key. returns a binary data with the
   # unhashed random iv in the first 16 bytes
   def self.encrypt(key, data)
-    cipher = OpenSSL::Cipher::Cipher.new(ENCRYPTION_METHOD)
+    cipher = OpenSSL::Cipher.new(ENCRYPTION_METHOD)
     cipher.encrypt
     cipher.key = key = OpenSSL::Digest::SHA256.digest(key)
     random_iv = cipher.random_iv
@@ -26,7 +26,7 @@ module Cryptr
   end
 
   def self.decrypt(key, data) # rubocop:disable Metrics/MethodLength
-    cipher = OpenSSL::Cipher::Cipher.new(ENCRYPTION_METHOD)
+    cipher = OpenSSL::Cipher.new(ENCRYPTION_METHOD)
     cipher.decrypt
     cipher.key = cipher_key = OpenSSL::Digest::SHA256.digest(key)
     random_iv = data[0...IV_LENGTH]

--- a/lib/cryptr.rb
+++ b/lib/cryptr.rb
@@ -73,13 +73,13 @@ module SimpleboxCryptr
   end
 
   def self.encrypt(key, data)
-    box = RbNaCl::SimpleBox.from_secret_key(key.force_encoding('BINARY'))
-    box.encrypt(data.force_encoding('BINARY'))
+    box = RbNaCl::SimpleBox.from_secret_key(key.clone.force_encoding('BINARY'))
+    box.encrypt(data.clone.force_encoding('BINARY'))
   end
 
   def self.decrypt(key, data)
-    box = RbNaCl::SimpleBox.from_secret_key(key.force_encoding('BINARY'))
-    box.decrypt(data.force_encoding('BINARY'))
+    box = RbNaCl::SimpleBox.from_secret_key(key.clone.force_encoding('BINARY'))
+    box.decrypt(data.clone.force_encoding('BINARY'))
   rescue RbNaCl::CryptoError
     nil
   end

--- a/lib/cryptr/version.rb
+++ b/lib/cryptr/version.rb
@@ -1,3 +1,3 @@
 module Cryptr
-  VERSION = '0.1.3'.freeze
+  VERSION = '0.1.4'.freeze
 end


### PR DESCRIPTION
Strings read from ENV variables are frozen by default, and usually encryption keys will be env variables.  `clone` returns a copy of the string that allows us to call `force_encoding` regardless of whether the passed in key is frozen.

`OpenSSL::Cipher::Cipher` is deprecated.