### PR TITLE
Fix frozen string bug for real

### DIFF
--- a/lib/cryptr.rb
+++ b/lib/cryptr.rb
@@ -73,13 +73,13 @@ module SimpleboxCryptr
   end
 
   def self.encrypt(key, data)
-    box = RbNaCl::SimpleBox.from_secret_key(key.clone.force_encoding('BINARY'))
-    box.encrypt(data.clone.force_encoding('BINARY'))
+    box = RbNaCl::SimpleBox.from_secret_key(key.dup.force_encoding('BINARY'))
+    box.encrypt(data.dup.force_encoding('BINARY'))
   end
 
   def self.decrypt(key, data)
-    box = RbNaCl::SimpleBox.from_secret_key(key.clone.force_encoding('BINARY'))
-    box.decrypt(data.clone.force_encoding('BINARY'))
+    box = RbNaCl::SimpleBox.from_secret_key(key.dup.force_encoding('BINARY'))
+    box.decrypt(data.dup.force_encoding('BINARY'))
   rescue RbNaCl::CryptoError
     nil
   end

--- a/lib/cryptr/version.rb
+++ b/lib/cryptr/version.rb
@@ -1,3 +1,3 @@
 module Cryptr
-  VERSION = '0.1.4'.freeze
+  VERSION = '0.1.5'.freeze
 end


### PR DESCRIPTION
`clone` preserves `frozen?` property, `dup` does not.