### PR TITLE
Remove rbnacl-libsodium gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,19 @@
 PATH
   remote: .
   specs:
-    cryptr (0.1.3)
+    cryptr (0.1.5)
       openssl
       rbnacl
-      rbnacl-libsodium
 
 GEM
   remote: https://rubygems.org/
   specs:
-    ffi (1.9.18)
+    ffi (1.9.25)
     minitest (5.10.3)
-    openssl (2.0.6)
+    openssl (2.1.1)
     rake (10.4.2)
     rbnacl (5.0.0)
       ffi
-    rbnacl-libsodium (1.0.13)
-      rbnacl (>= 3.0.1)
 
 PLATFORMS
   ruby
@@ -28,4 +25,4 @@ DEPENDENCIES
   rake (~> 10.0)
 
 BUNDLED WITH
-   1.16.0.pre.2
+   1.16.1

--- a/cryptr.gemspec
+++ b/cryptr.gemspec
@@ -31,7 +31,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "openssl"
-  spec.add_dependency "rbnacl-libsodium"
   spec.add_dependency "rbnacl"
 
   spec.add_development_dependency "bundler", "~> 1.16.a"

--- a/lib/cryptr/version.rb
+++ b/lib/cryptr/version.rb
@@ -1,3 +1,3 @@
 module Cryptr
-  VERSION = '0.1.5'.freeze
+  VERSION = '0.1.6.beta.1'.freeze
 end


### PR DESCRIPTION
remove `rbnacl-libsodium` and leverage native `libsodium` to speed up the bundle process.

Going to test it with beta version first.